### PR TITLE
Support specifying a view name (table:view) when querying

### DIFF
--- a/airtable_export/cli.py
+++ b/airtable_export/cli.py
@@ -54,7 +54,7 @@ def cli(output_path, base_id, tables, key, verbose, json, ndjson, yaml, sqlite):
         records = []
         try:
             db_batch = []
-            for record in all_records(base_id, table, key):
+            for record in all_records(base_id, table, key, view=view):
                 r = {
                     **{"airtable_id": record["id"]},
                     **record["fields"],

--- a/airtable_export/cli.py
+++ b/airtable_export/cli.py
@@ -112,7 +112,7 @@ def all_records(base_id, table, api_key, view=None, sleep=0.2):
             url += "?" + urlencode(query)
 
         response = httpx.get(
-            url, headers={"Authorization": "Bearer {}".format(api_key)}
+            url, headers={"Authorization": "Bearer {}".format(api_key), "User-Agent": "curl/7.64.1"}
         )
         response.raise_for_status()
         data = response.json()

--- a/tests/test_airtable_export.py
+++ b/tests/test_airtable_export.py
@@ -103,6 +103,35 @@ def test_airtable_export(mocked, format, expected):
         ).read()
         assert expected.strip() == actual.strip()
 
+@pytest.mark.parametrize("format,expected", FORMATS)
+def test_airtable_export_with_view_name(mocked, format, expected):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        args = [
+            ".",
+            "appZOGvNJPXCQ205F",
+            "tablename:viewname",
+            "-v",
+            "--key",
+            "x",
+            "--{}".format(format),
+        ]
+        result = runner.invoke(
+            cli.cli,
+            args,
+        )
+        assert 0 == result.exit_code
+        assert (
+            "Wrote 2 records to tablename_viewname.{}".format(
+                "yml" if format == "yaml" else format
+            )
+            == result.output.strip()
+        )
+        actual = open(
+            "tablename_viewname.{}".format("yml" if format == "yaml" else format)
+        ).read()
+        assert expected.strip() == actual.strip()
+
 
 def test_all_three_formats_at_once(mocked):
     runner = CliRunner()


### PR DESCRIPTION
Hi @simonw,

Here's a small improvement. I use `airtable-export` for {in,up}serting data into a SQLite db (with `sqlite-utils` of course :)). The rows that I need to sync are selected by a boolean condition that I've added as a filter in a table view.

This change adds support for querying _views_. Eg:

```bash
airtable-export export appbeErMVynhHKIYQ table1:new_records table2 "table3:view name with spaces" --ndjson --key keyxxxxxx
```

Thanks for your great work with the `datasette` ecosystem of tools 💪🏽