### PR TITLE
feat: set user agent with --user-agent flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ You can pass multiple format options at once. This command will create a `.json`
     airtable-export export base_id table1 table2 \
         --key=key --ndjson --yaml --json
 
+## Request options
+
+By default the tool uses [python-httpx](https://www.python-httpx.org)'s default configurations.
+
+You can override the `user-agent` using the `--user-agent` option:
+
+    airtable-export export base_id table1 table2 --key=key --user-agent "Airtable Export Robot"
+
 ### SQLite database export
 
 You can export tables to a SQLite database file using the `--sqlite database.db` option:

--- a/README.md
+++ b/README.md
@@ -42,14 +42,6 @@ You can pass multiple format options at once. This command will create a `.json`
     airtable-export export base_id table1 table2 \
         --key=key --ndjson --yaml --json
 
-## Request options
-
-By default the tool uses [python-httpx](https://www.python-httpx.org)'s default configurations.
-
-You can override the `user-agent` using the `--user-agent` option:
-
-    airtable-export export base_id table1 table2 --key=key --user-agent "Airtable Export Robot"
-
 ### SQLite database export
 
 You can export tables to a SQLite database file using the `--sqlite database.db` option:
@@ -62,6 +54,14 @@ This can be combined with other format options. If you only specify `--sqlite` t
 The SQLite database will have a table created for each table you export. Those tables will have a primary key column called `airtable_id`.
 
 If you run this command against an existing SQLite database records with matching primary keys will be over-written by new records from the export.
+
+## Request options
+
+By default the tool uses [python-httpx](https://www.python-httpx.org)'s default configurations.
+
+You can override the `user-agent` using the `--user-agent` option:
+
+    airtable-export export base_id table1 table2 --key=key --user-agent "Airtable Export Robot"
 
 ## Running this using GitHub Actions
 

--- a/airtable_export/cli.py
+++ b/airtable_export/cli.py
@@ -33,7 +33,9 @@ import yaml as yaml_
     type=click.Path(file_okay=True, dir_okay=False, allow_dash=False),
     help="Export to this SQLite database",
 )
-def cli(output_path, base_id, tables, key, user_agent, verbose, json, ndjson, yaml, sqlite):
+def cli(
+    output_path, base_id, tables, key, user_agent, verbose, json, ndjson, yaml, sqlite
+):
     "Export Airtable data to YAML file on disk"
     output = pathlib.Path(output_path)
     output.mkdir(parents=True, exist_ok=True)
@@ -91,7 +93,7 @@ def cli(output_path, base_id, tables, key, user_agent, verbose, json, ndjson, ya
 
 
 def all_records(base_id, table, api_key, sleep=0.2, user_agent=None):
-    headers={"Authorization": "Bearer {}".format(api_key)}
+    headers = {"Authorization": "Bearer {}".format(api_key)}
     if user_agent is not None:
         headers["user-agent"] = user_agent
 
@@ -102,9 +104,7 @@ def all_records(base_id, table, api_key, sleep=0.2, user_agent=None):
         url = "https://api.airtable.com/v0/{}/{}".format(base_id, quote(table))
         if offset:
             url += "?" + urlencode({"offset": offset})
-        response = httpx.get(
-            url, headers=headers
-        )
+        response = httpx.get(url, headers=headers)
         response.raise_for_status()
         data = response.json()
         offset = data.get("offset")

--- a/airtable_export/cli.py
+++ b/airtable_export/cli.py
@@ -23,7 +23,7 @@ import yaml as yaml_
 )
 @click.argument("tables", type=str, nargs=-1)
 @click.option("--key", envvar="AIRTABLE_KEY", help="Airtable API key", required=True)
-@click.option("--user-agent", help="User agent to use for requests", default="")
+@click.option("--user-agent", help="User agent to use for requests")
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("--json", is_flag=True, help="JSON format")
 @click.option("--ndjson", is_flag=True, help="Newline delimited JSON format")
@@ -90,10 +90,10 @@ def cli(output_path, base_id, tables, key, user_agent, verbose, json, ndjson, ya
             )
 
 
-def all_records(base_id, table, api_key, sleep=0.2, user_agent=""):
+def all_records(base_id, table, api_key, sleep=0.2, user_agent=None):
     headers={"Authorization": "Bearer {}".format(api_key)}
-    if user_agent != "":
-        headers["user-agent"]=user_agent
+    if user_agent is not None:
+        headers["user-agent"] = user_agent
 
     first = True
     offset = None


### PR DESCRIPTION
It may be desirable for a user to configure `airtable-export`'s user-agent to better identify the tool's usage to AirTable.

Allow setting this option using a command line flag.