### PR TITLE
feat: override read timeout via --http-read-timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ You can override the `user-agent` using the `--user-agent` option:
 
     airtable-export export base_id table1 table2 --key=key --user-agent "Airtable Export Robot"
 
+You can override the [timeout during a network read operation](https://www.python-httpx.org/advanced/#fine-tuning-the-configuration) using the `--http-read-timeout` option. If not set, this defaults to 5s.
+
+    airtable-export export base_id table1 table2 --key=key --http-read-timeout 60
+
 ## Running this using GitHub Actions
 
 [GitHub Actions](https://github.com/features/actions) is GitHub's workflow automation product. You can use it to run `airtable-export` in order to back up your Airtable data to a GitHub repository. Doing this gives you a visible commit history of changes you make to your Airtable data - like [this one](https://github.com/natbat/rockybeaches/commits/main/airtable).

--- a/airtable_export/cli.py
+++ b/airtable_export/cli.py
@@ -23,7 +23,11 @@ import yaml as yaml_
 )
 @click.argument("tables", type=str, nargs=-1)
 @click.option("--key", envvar="AIRTABLE_KEY", help="Airtable API key", required=True)
-@click.option("--http-read-timeout", help="Timeout (in seconds) for network read operations", default=5)
+@click.option(
+    "--http-read-timeout",
+    help="Timeout (in seconds) for network read operations",
+    default=5,
+)
 @click.option("--user-agent", help="User agent to use for requests")
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("--json", is_flag=True, help="JSON format")
@@ -35,7 +39,17 @@ import yaml as yaml_
     help="Export to this SQLite database",
 )
 def cli(
-    output_path, base_id, tables, key, http_read_timeout, user_agent, verbose, json, ndjson, yaml, sqlite
+    output_path,
+    base_id,
+    tables,
+    key,
+    http_read_timeout,
+    user_agent,
+    verbose,
+    json,
+    ndjson,
+    yaml,
+    sqlite,
 ):
     "Export Airtable data to YAML file on disk"
     output = pathlib.Path(output_path)
@@ -52,7 +66,9 @@ def cli(
         records = []
         try:
             db_batch = []
-            for record in all_records(base_id, table, key, http_read_timeout, user_agent=user_agent):
+            for record in all_records(
+                base_id, table, key, http_read_timeout, user_agent=user_agent
+            ):
                 r = {
                     **{"airtable_id": record["id"]},
                     **record["fields"],
@@ -99,8 +115,8 @@ def all_records(base_id, table, api_key, http_read_timeout, sleep=0.2, user_agen
         headers["user-agent"] = user_agent
 
     # If left unconfigured, httpx defaults to 5s timeout. Use the same here.
-    timeout=httpx.Timeout(5, read=http_read_timeout)
-    client=httpx.Client(timeout=timeout)
+    timeout = httpx.Timeout(5, read=http_read_timeout)
+    client = httpx.Client(timeout=timeout)
 
     first = True
     offset = None


### PR DESCRIPTION
Occasionally `airtable-export` fails due to a timeout on read out with an error like:
```txt
Error: The read operation timed out
```

This occurs intermittently, particularly when interacting with a large number of records in quick succession during an export.

Allow configuration of [`python-httpx`'s read timeout](https://www.python-httpx.org/advanced/#fine-tuning-the-configuration) as needed. In recent testing where I previously had the above error, setting a 60s timeout (default is 5s) appears to eliminate `airtable-export` failures.