### PR TITLE
Documentation for backup to another repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
+      # in case you forked airtable-export to a public repository and prefer to have the backups in a private one
+      # add a personal access token as github secret named ACCESSTOKEN
+      # otherwise just remove the following 'with' section
+      with:
+        repository: 'mygithubname/my_backup_repository'
+        ref: 'main'
+        token: ${{ secrets.accesstoken }}
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
When you fork airtable-export on github the project is public and you cant set it to private. You may not want to have your data public, so I added a remark on how to backup to another repository to readme.md 